### PR TITLE
feat/set

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Usage](#usage)
+    - [mapKeys()](#mapkeys)
+    - [set()](#set)
 - [Local Development](./LOCAL_DEVELOPMENT.md)
 - [Contributing](#contributing)
 
@@ -40,7 +42,7 @@ This will add the package to your project’s dependencies and create an autoloa
 
 ## Usage
 
-### mapKeys
+### mapKeys()
 
 Map keys of an array like this:
 
@@ -56,6 +58,33 @@ $new_array = Arr::mapKeys($array, function (string $key) {
 });
 
 $key2 = $new_array['key1']['key2']);
+```
+
+### set()
+
+Set values in arrays using dot notation, merge arrays, or use callbacks:
+
+```php
+
+// Set value with dot notation
+$array = ['a' => ['b' => 1]];
+$new_array = Arr::set($array, 'a.b', 2); // ['a' => ['b' => 2]]
+
+// Merge arrays
+$array1 = ['a' => 1];
+$array2 = ['b' => 2];
+$new_array = Arr::set($array1, $array2); // ['a' => 1, 'b' => 2]
+
+// Use a callback
+$array = ['a' => 1];
+$new_array = Arr::set($array, function($array) {
+    $array['b'] = 2;
+    return $array;
+}); // ['a' => 1, 'b' => 2]
+
+// Empty string key does not modify the array
+$array = ['a' => 1];
+$new_array = Arr::set($array, ''); // ['a' => 1]
 ```
 
 ## Contributing

--- a/bin/arr
+++ b/bin/arr
@@ -1,4 +1,0 @@
-#!/usr/bin/env php
-<?php
-
-require getcwd().'/vendor/autoload.php';

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -13,9 +13,11 @@ class Arr
      * @template TValue
      * @template TNewKey of array-key
      *
-     * @param  array<TKey, TValue>  $array
+     * @param  array<TKey, TValue>      $array
      * @param  callable(TKey): TNewKey  $callback
+     *
      * @return array<TNewKey, TValue>
+     * @link    https://github.com/zero-to-prod/arr
      */
     public static function mapKeys(array $array, callable $callback): array
     {
@@ -28,5 +30,56 @@ class Arr
         }
 
         return $result;
+    }
+
+    /**
+     * Set a value on an array with dot syntax or merge with another array/callback.
+     *
+     * This method allows setting values in nested arrays by using dot notation for keys,
+     * merging arrays, or applying a callback function to modify the array.
+     *
+     * ```
+     * Arr::set(['a' => 1], 'b.c', 2) returns ['a' => 1, 'b' => ['c' => 2]]
+     * Arr::set(['a' => 1], ['b' => 2]) returns ['a' => 1, 'b' => 2]
+     * Arr::set(['a' => 1], function($array) { $array['b'] = 2; return $array; }) returns ['a' => 1, 'b' => 2]
+     *```
+     *
+     *
+     * @template TKey of array-key
+     * @template TValue
+     * @template TNewKey of array-key
+     *
+     * @param  array<TKey, TValue>    $array  The array to modify
+     * @param  callable|array|string  $key    If `$key` is string, dot notation for nested keys; if `$key` is array, merges with `$array`; if callable, modifies `$array`
+     * @param  TValue|null            $value  The value to set when `$key`` is a string (optional)
+     *
+     * @return array<TKey|TNewKey, TValue> The modified array
+     * @link    https://github.com/zero-to-prod/arr
+     */
+    public static function set(array $array, $key, $value = null): array
+    {
+        if ($key === '') {
+            return $array;
+        }
+
+        if (is_string($key)) {
+            $ref = &$array;
+
+            foreach (explode('.', $key) as $sub_key) {
+                if (!isset($ref[$sub_key]) || !is_array($ref[$sub_key])) {
+                    $ref[$sub_key] = [];
+                }
+                $ref = &$ref[$sub_key];
+            }
+
+            $ref = $value;
+
+            return $array;
+        }
+
+        return array_merge(
+            $array,
+            is_callable($key) ? $key($array) : $key
+        );
     }
 }

--- a/tests/Unit/SetTest.php
+++ b/tests/Unit/SetTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Zerotoprod\Arr\Arr;
+
+class SetTest extends TestCase
+{
+    /** @test */
+    public function it_can_set_a_value_with_dot_notation(): void
+    {
+        $array = [
+            'Key1' => [
+                'Key2' => 1
+            ]
+        ];
+
+        $new_array = Arr::set($array, 'Key1.Key2', 2);
+
+        $this->assertEquals([
+            'Key1' => [
+                'Key2' => 2
+            ]
+        ], $new_array);
+    }
+
+    /** @test */
+    public function it_creates_intermediate_keys_if_they_do_not_exist(): void
+    {
+        $array = [];
+
+        $new_array = Arr::set($array, 'Key1.Key2.Key3', 'value');
+
+        $this->assertEquals([
+            'Key1' => [
+                'Key2' => [
+                    'Key3' => 'value'
+                ]
+            ]
+        ], $new_array);
+    }
+
+    /** @test */
+    public function it_can_set_a_value_in_a_nested_array(): void
+    {
+        $array = [
+            'user' => [
+                'info' => [
+                    'name' => 'John'
+                ]
+            ]
+        ];
+
+        $new_array = Arr::set($array, 'user.info.name', 'Jane');
+
+        $this->assertEquals([
+            'user' => [
+                'info' => [
+                    'name' => 'Jane'
+                ]
+            ]
+        ], $new_array);
+    }
+
+    /** @test */
+    public function it_can_set_a_value_with_no_dot_notation(): void
+    {
+        $array = [];
+        $new_array = Arr::set($array, 'key', 'value');
+
+        $this->assertEquals(['key' => 'value'], $new_array);
+    }
+
+    /** @test */
+    public function it_merges_arrays_when_key_is_not_a_string(): void
+    {
+        $array = ['a' => 1];
+        $new_array = Arr::set($array, ['b' => 2]);
+
+        $this->assertEquals(['a' => 1, 'b' => 2], $new_array);
+    }
+
+    /** @test */
+    public function it_uses_a_callback_to_modify_the_array(): void
+    {
+        $array = ['a' => 1];
+        $new_array = Arr::set($array, function ($array) {
+            $array['b'] = 2;
+
+            return $array;
+        });
+
+        $this->assertEquals(['a' => 1, 'b' => 2], $new_array);
+    }
+
+    /** @test */
+    public function it_handles_an_empty_string_for_key(): void
+    {
+        $array = ['a' => 1];
+        $new_array = Arr::set($array, '', 'value');
+
+        $this->assertEquals(['a' => 1], $new_array);
+    }
+
+    /** @test */
+    public function it_handles_an_empty_array_as_key(): void
+    {
+        $array = ['a' => 1];
+        $new_array = Arr::set($array, []);
+
+        $this->assertEquals(['a' => 1], $new_array);
+    }
+
+    /** @test */
+    public function it_does_not_modify_the_original_array(): void
+    {
+        $original = ['a' => 1];
+        Arr::set($original, 'b', 2);
+
+        $this->assertEquals(['a' => 1], $original);
+    }
+}


### PR DESCRIPTION
## Description
### set()

Set values in arrays using dot notation, merge arrays, or use callbacks:

```php

// Set value with dot notation
$array = ['a' => ['b' => 1]];
$new_array = Arr::set($array, 'a.b', 2); // ['a' => ['b' => 2]]

// Merge arrays
$array1 = ['a' => 1];
$array2 = ['b' => 2];
$new_array = Arr::set($array1, $array2); // ['a' => 1, 'b' => 2]

// Use a callback
$array = ['a' => 1];
$new_array = Arr::set($array, function($array) {
    $array['b'] = 2;
    return $array;
}); // ['a' => 1, 'b' => 2]

// Empty string key does not modify the array
$array = ['a' => 1];
$new_array = Arr::set($array, ''); // ['a' => 1]
```